### PR TITLE
set sass-rails v5.0

### DIFF
--- a/toastr-rails-sass.gemspec
+++ b/toastr-rails-sass.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.23"
   s.summary = "Toastr: Simple javascript toast notifications"
 
-  s.add_dependency(%q<sass-rails>, ["~> 3.2"])
+  s.add_dependency(%q<sass-rails>, ["~> 5.0"])
 
 end
-


### PR DESCRIPTION
To fix

```
Bundler could not find compatible versions for gem "railties":
  In Gemfile:
    coffee-rails (~> 4.2) was resolved to 4.2.1, which depends on
      railties (< 5.2.x, >= 4.0.0)

    rails (~> 5.0.0) was resolved to 5.0.0, which depends on
      railties (= 5.0.0)

    sass-rails (~> 5.0) was resolved to 5.0.0, which depends on
      railties (< 5.0, >= 4.0.0)
```
